### PR TITLE
Change module name to github.com/rntrp/bimg-rest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module example.com/bimg-rest
+module github.com/rntrp/bimg-rest
 
 go 1.16
 


### PR DESCRIPTION
It is common and convenient to give Go modules names, that are valid VCS-URLs. This way packages can easily be installed with `go get`. For example: If you merge #2 as well as this pull request, you can install a binary called `bimg-rest` directly to `~/go/bin/` by simply running `go get github.com/rntrp/bimg-rest`.

Right now this does not work:
```console
$ go get github.com/rntrp/bimg-rest
go get: github.com/rntrp/bimg-rest@none updating to
        github.com/rntrp/bimg-rest@v0.0.0-20210831051953-0574d8b8379d: parsing go.mod:
        module declares its path as: example.com/bimg-rest
                but was required as: github.com/rntrp/bimg-rest
```